### PR TITLE
CUser 엔티티 아이디값제한+ 비밀번호 찾기

### DIFF
--- a/CWebProj/build.gradle
+++ b/CWebProj/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'io.springfox:springfox-swagger2:3.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/CWebProj/src/main/java/com/example/CWebProj/User/CUser.java
+++ b/CWebProj/src/main/java/com/example/CWebProj/User/CUser.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.Email;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -20,14 +21,15 @@ public class CUser {
 	private Integer cid;
 
 	@Column(unique = true)
-	private String username; // 아이디
+	@Email(message = "이메일이 유효해야합니다.")
+	private String username; // 아이디 -> 이메일로 가입하게끔
 	private String password; // 비밀번호
 	private boolean enabled; //
 	private String role; // 권한
 
 	@Column(unique = true)
-	private String cemail; // 이메일
 	private String cname; //이름
 	private LocalDateTime cdate; // 날짜
+	
 	
 }

--- a/CWebProj/src/main/java/com/example/CWebProj/User/CUserController.java
+++ b/CWebProj/src/main/java/com/example/CWebProj/User/CUserController.java
@@ -1,19 +1,22 @@
 package com.example.CWebProj.User;
 
 import java.net.URI;
+import java.security.Principal;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 
 @Controller
 public class CUserController {
@@ -30,6 +33,7 @@ public class CUserController {
 	public String signup(CUser cuser) {
 		cuserService.create(cuser);
 		return "user/signup";
+		
 	}
 
 	@GetMapping("/signin")
@@ -52,14 +56,27 @@ public class CUserController {
 		return "user/findid";
 	}
 
-	@PreAuthorize("isAnonymous()")
 	@GetMapping("/findpw")
 	public String findpw() {
 		return "user/findpw";
 	}
 
+	@PostMapping("/findpw")
+	public String findpw(Model model, @RequestParam("username") String username,
+	                     @Valid CUserForm cuserForm, BindingResult bindingResult, Principal principal) {
+	    CUser cuser = this.cuserService.findpw(username);
+
+	    if (bindingResult.hasErrors()) {
+	        model.addAttribute("cuser", cuser);
+	        return "user/resetpw";
+	    }
+	    return "redirect:/signin"; 
+	}
 	
-	
+	@GetMapping("/resetpw")
+	public String resetpw() {
+		return "user/resetpw";
+	}
 	
 	//구글 로그인
 	@Value("${spring.security.oauth2.client.registration.google.client-id}")

--- a/CWebProj/src/main/java/com/example/CWebProj/User/CUserForm.java
+++ b/CWebProj/src/main/java/com/example/CWebProj/User/CUserForm.java
@@ -1,0 +1,21 @@
+package com.example.CWebProj.User;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CUserForm {
+
+	@Size(min = 7,max=25)
+	@NotEmpty(message = "아이디는 이메일 아이디로 가입해주세요. 필수항목입니다.")
+    private String username;
+    
+	@NotEmpty(message = "비밀번호는 필수항목입니다.")
+    private String password1; //비밀번호
+
+	@NotEmpty(message = "비밀번호 확인은 필수항목입니다.")
+    private String password2; //비밀번호 확인을 위한 거
+}

--- a/CWebProj/src/main/java/com/example/CWebProj/User/CUserRepository.java
+++ b/CWebProj/src/main/java/com/example/CWebProj/User/CUserRepository.java
@@ -10,7 +10,5 @@ import org.springframework.data.repository.query.Param;
 import jakarta.transaction.Transactional;
 
 public interface CUserRepository extends JpaRepository<CUser, Integer> {
-	Optional<CUser> findByusername(String username); // login check
-
-	Optional<CUser> findByCemail(String cemail);
+	Optional<CUser> findByUsername(String username); // login check
 }

--- a/CWebProj/src/main/java/com/example/CWebProj/User/DataNotFoundException.java
+++ b/CWebProj/src/main/java/com/example/CWebProj/User/DataNotFoundException.java
@@ -1,0 +1,12 @@
+package com.example.CWebProj.User;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "entity not found")
+public class DataNotFoundException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+    public DataNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/CWebProj/src/main/java/com/example/CWebProj/User/GooglemailService.java
+++ b/CWebProj/src/main/java/com/example/CWebProj/User/GooglemailService.java
@@ -1,0 +1,5 @@
+package com.example.CWebProj.User;
+
+public interface GooglemailService {
+
+}

--- a/CWebProj/src/main/resources/application.properties
+++ b/CWebProj/src/main/resources/application.properties
@@ -39,7 +39,7 @@ spring.profiles.include=oauth
 Spring.mail.host = smtp.gmail.com
 Spring.mail.port= 465
 Spring.mail.username=areumdownchurch1@gmail.com
-Spring.mail.password =lddn jrgi tqjp upkx
+Spring.mail.password=lddn jrgi tqjp upkx
 
 Spring.mail.properties.mail.smtp.auth = true
 Spring.mail.properties.mail.smtp.timeout = 5000
@@ -47,12 +47,3 @@ Spring.mail.properties.mail.smtp.strattls.enable = true
 spring.mail.properties.mail.smtp.starttls.required=true
 spring.mail.properties.mail.smtp.ssl.enable=true
 spring.mail.properties.mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
-
-
-# SMTP 설정
-mail.host=smtp.gmail.com
-mail.port=587
-mail.username=areumdownchurch1@gmail.com
-mail.password=lddn jrgi tqjp upkx
-mail.smtp.starttls.enable=true
-mail.smtp.auth=true

--- a/CWebProj/src/main/resources/templates/fragment/header.html
+++ b/CWebProj/src/main/resources/templates/fragment/header.html
@@ -11,7 +11,7 @@
                 <div class="social-links d-none d-md-flex align-items-center">
                   
 
-                  	<a href="/banner">배너 변경 페이지</a>
+                  	<a th:if="${#authorization.expression('hasRole(''ADMIN'')')}" th:href="@{/banner}">배너 변경 페이지</a>
                   	<a th:if="${#authorization.expression('hasRole(''ADMIN'')')}" th:href="@{/autho}">권한체크페이지</a>
                   	<a href="/test">테스트 페이지</a>
                     <a sec:authorize="isAnonymous()" th:href="@{/signin}">로그인</a>

--- a/CWebProj/src/main/resources/templates/user/findpw.html
+++ b/CWebProj/src/main/resources/templates/user/findpw.html
@@ -1,39 +1,31 @@
 <div class="container">
-    <!-- Modal -->
-    <div class="modal fade" id="myModal" role="dialog">
-        <div class="modal-dialog">
+	<!-- Modal -->
+	<div class="modal fade" id="myModal" role="dialog">
+		<div class="modal-dialog">
 
-            <!-- Modal content-->
-            <div class="modal-content">
-                <div class="modal-header" style="padding:35px 50px;">
-                    <h4><span class="glyphicon glyphicon-lock"></span> 비밀번호 찾기</h4>
-                </div>
-                <div class="modal-body" style="padding:40px 50px;">
-                    <div style="color: #ac2925">
-                        <center>입력된 정보로 임시 비밀번호가 전송됩니다.</center>
-                    </div>
-                    <hr>
-                    <form role="form">
-                        <div class="form-group">
-                            <label for="userEmail"><span class="glyphicon glyphicon-user"></span>이메일</label>
-                            <input type="text" class="form-control" id="userEmail" placeholder="가입시 등록한 이메일을 입력하세요.">
-                        </div>
-                        <div class="form-group">
-                            <label for="userName"><span class="glyphicon glyphicon-eye-open"></span> 이름</label>
-                            <input type="text" class="form-control" id="userName" placeholder="가입시 등록한 이름을 입력하세요.">
-                        </div>
-                        <button type="button" class="btn btn-success btn-block" id="checkEmail">확인</button>
-                    </form>
-                    <hr>
-                    <div class="text-center small mt-2" id="checkMsg" style="color: red"></div>
-                </div>
-                <div class="modal-footer">
-                    <button type="submit" class="btn btn-danger btn-default pull-left" data-dismiss="modal"><span
-                            class="glyphicon glyphicon-remove"></span> 취소
-                    </button>
-                </div>
-            </div>
+			<!-- Modal content-->
+			<div class="modal-content">
+				<div class="modal-header" style="padding: 35px 50px;">
+					<h4>
+						<span class="glyphicon glyphicon-lock"></span> 비밀번호 찾기
+					</h4>
+				</div>
+				<div class="modal-body" style="padding: 40px 50px;">
+						<center>입력된 정보로 임시 비밀번호가 전송됩니다.</center>
+					</div>
+					<hr>
+				<form action="/findpw" method="post">
+					<input type="hidden" th:name="${_csrf.parameterName}"
+						th:value="${_csrf.token}" />
+					<p>
+						이메일 : <input type="text" name="username" placeholder="가입시 등록한 이메일을 입력하세요.">
+					<p>
+						<input type="submit" value="비밀번호 찾기">
+						<a href="/"> 메인으로 가기</a>
+				</form>
+			</div>
+		</div>
 
-        </div>
-    </div>
+	</div>
+</div>
 </div>

--- a/CWebProj/src/main/resources/templates/user/resetpw.html
+++ b/CWebProj/src/main/resources/templates/user/resetpw.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Insert title here</title>
+</head>
+<body>
+<h3>비밀번호를 다시 설정하세요</h3>
+<form action="/resetpw" method = "post">
+<input type="hidden" th:name="${_csrf.parameterName}"
+			th:value="${_csrf.token}" />
+		<p>
+			비밀번호 : <input type="text" name="password1">
+		<p>
+			비밀번호 확인 : <input type="password" name="password2"> 
+			<input type="submit" value="비밀번호 재설정">
+	</form>
+
+</form>
+</body>
+</html>

--- a/CWebProj/src/main/resources/templates/user/signup.html
+++ b/CWebProj/src/main/resources/templates/user/signup.html
@@ -17,13 +17,11 @@
 		<input type="hidden" th:name="${_csrf.parameterName}"
 			th:value="${_csrf.token}" />
 		<p>
-			아이디 : <input type="text" name="username">
+			아이디 : <input type="text" name="username" placeholder= "aaaa@google.com">
 		<p>
-			비밀번호 : <input type="password" name="password">
+			비밀번호 : <input type="password" name="password" placeholder="비밀번호를 입력하세요">
 		<p>
-			이메일 : <input type="text" name="cemail">
-		<p>
-			이름 : <input type="text" name="cname">
+			이름 : <input type="text" name="cname" placeholder="이름을 입력하세요.">
 		<p> 
 			<input type="submit" value="회원가입">
 	</form>


### PR DESCRIPTION
회원가입창에서 이메일을 삭제하고 아이디에 이메일형식으로만 가입하게 만듦
비번찾기 -> 비번찾기 페이지에서 입력한 이메일이 db에서 꺼낸 아이디와 비교하여 이메일이 같으면 비번 재설정 창으로 가게해둠 CUserForm은 삭제해도 됨
배너변경페이지 역시 admin권한일때만 보이도록 변경